### PR TITLE
chore: bump lucide-svelte 0.577 → 1.0 (replace removed brand icons)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
 		"vite": "^8.0.10"
 	},
 	"dependencies": {
-		"lucide-svelte": "^0.577.0"
+		"lucide-svelte": "^1.0.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       lucide-svelte:
-        specifier: ^0.577.0
-        version: 0.577.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^1.0.1
+        version: 1.0.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.5
@@ -1176,8 +1176,8 @@ packages:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
-  lucide-svelte@0.577.0:
-    resolution: {integrity: sha512-0i88o57KsaHWnc80J57fY99CWzlZsSdtH5kKjLUJa7z8dum/9/AbINNLzJ7NiRFUdOgMnfAmJt8jFbW2zeC5qQ==}
+  lucide-svelte@1.0.1:
+    resolution: {integrity: sha512-WvzZgk0pqzgda+AErLvgWxHkfg/+GgUwqKMRHvzt0IqyMdmyEDzDCk3Z+Wo/3y753oIgx8u9Q4eUbWkghFa8Jg==}
     peerDependencies:
       svelte: ^3 || ^4 || ^5.0.0-next.42
 
@@ -2518,7 +2518,7 @@ snapshots:
 
   lru-cache@11.3.5: {}
 
-  lucide-svelte@0.577.0(svelte@5.55.5(@typescript-eslint/types@8.59.1)):
+  lucide-svelte@1.0.1(svelte@5.55.5(@typescript-eslint/types@8.59.1)):
     dependencies:
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
 

--- a/src/lib/components/icons/Github.svelte
+++ b/src/lib/components/icons/Github.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	let { color = 'currentColor', size = 24 }: { color?: string; size?: number | string } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	width={size}
+	height={size}
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke={color}
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+>
+	<path
+		d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"
+	/>
+	<path d="M9 18c-4.51 2-5-2-7-2" />
+</svg>

--- a/src/lib/components/icons/Linkedin.svelte
+++ b/src/lib/components/icons/Linkedin.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	let { color = 'currentColor', size = 24 }: { color?: string; size?: number | string } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	width={size}
+	height={size}
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke={color}
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+>
+	<path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
+	<rect width="4" height="12" x="2" y="9" />
+	<circle cx="4" cy="4" r="2" />
+</svg>

--- a/src/lib/sections/SubHeader.svelte
+++ b/src/lib/sections/SubHeader.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import SubNavItem from '$lib/components/header/SubNavItem.svelte';
-	import { Github, Linkedin, Phone, MapPinned, Mail } from 'lucide-svelte';
+	import Github from '$lib/components/icons/Github.svelte';
+	import Linkedin from '$lib/components/icons/Linkedin.svelte';
+	import { Phone, MapPinned, Mail } from 'lucide-svelte';
 
 	let hovered: number = $state(-1);
 </script>


### PR DESCRIPTION
## Summary
- \`lucide-svelte\` 0.577.0 → 1.0.1
- v1 removed brand icons (Github, Linkedin, etc.) — replaced with local SVG components at \`src/lib/components/icons/Github.svelte\` and \`Linkedin.svelte\`, copied from lucide v0.577's iconNode paths.
- The new components mirror lucide's API (\`color\` / \`size\` props), so \`SubHeader.svelte\` only changed its imports.

## Test plan
- [x] \`pnpm run check\` — clean
- [x] \`pnpm run build\` — clean
- [x] \`pnpm run lint\` — clean
- [ ] Browser smoke-test: SubHeader Github + LinkedIn icons render with white stroke, hover/scale interactions still work